### PR TITLE
Ensure pager interprets escape sequences

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -308,6 +308,13 @@ def get_pager_cmd(pager_cmd=None):
             pager_cmd = os.environ['PAGER']
         except:
             pager_cmd = default_pager_cmd
+    
+    if pager_cmd == 'less':
+    try:
+        os.getenv('LESS').index('-r')
+    except (ValueError, AttributeError):
+        pager_cmd += ' -r'
+    
     return pager_cmd
 
 

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -310,10 +310,10 @@ def get_pager_cmd(pager_cmd=None):
             pager_cmd = default_pager_cmd
     
     if pager_cmd == 'less':
-    try:
-        os.getenv('LESS').index('-r')
-    except (ValueError, AttributeError):
-        pager_cmd += ' -r'
+        try:
+            os.getenv('LESS').index('-r')
+        except (ValueError, AttributeError):
+            pager_cmd += ' -r'
     
     return pager_cmd
 


### PR DESCRIPTION
If less is specified in $PAGER, but $LESS either doesn't exist or doesn't contain `-r` option, append `-r` to the pager command string.
